### PR TITLE
Fix incorrect <link> tag causing href text to appear on page

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link>
+    <link 
       href="https://cdn.jsdelivr.net/npm/remixicon@3.4.0/fonts/remixicon.css"
       rel="stylesheet"
-    </link>
+    />
     <link rel="stylesheet" href="styles.css" />
     <title>BODY CRAFT GYM</title>
   </head>


### PR DESCRIPTION
Fixes #2  
This PR corrects the malformed <link> tag in the <head> section of the HTML. The original tag was improperly structured with a separate closing </link> and inner content, which caused the href value to be rendered as visible text on the webpage.