### PR TITLE
fix: corrected button text casing from 'Book A Class' to 'Book a Class'

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
           challenged, ensuring you never hit a plateau in your fitness
           endeavors.
         </p>
-        <button class="btn">Book A Class</button>
+        <button class="btn">Book a Class</button>
       </div>
     </section>
 


### PR DESCRIPTION
This PR fixes issue #25 by changing "Book A Class" to "Book a Class" as per the style guide. Improves consistency and readability.

<img width="430" height="171" alt="image" src="https://github.com/user-attachments/assets/2629e817-719e-427a-8b7b-fb34defead96" />

