### PR TITLE
Add Pricing Plan page with Navigation Intergration

### DIFF
--- a/Pricing Plan.html
+++ b/Pricing Plan.html
@@ -1,0 +1,99 @@
+
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+          <meta charset="UTF-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1.0">
+          <title>Pricing Plan</title>
+          <link rel="stylesheet" href="styles.css">
+        </head>
+
+        <body>
+          <nav>
+      
+      </div>
+      <ul class="nav__links">
+        <li class="link"><a href="index.html">Home</a></li>
+        <li class="link"><a href="index.html">Program</a></li>
+        <li class="link"><a href="index.html">Service</a></li>
+        <li class="link"><a href="index.html#diet-plan">Diet Plan</a></li>
+        <li class="link"><a href="index.html">About</a></li>
+        <li class="link"><a href="Pricing Plan.html">Pricing Plan</a></li>
+        <li class="link"><a href="contact.html">Contact Us</a></li>
+      </ul>
+      <button class="btn">Join Now</button>
+    </nav>
+          <section class="section__container price__container">
+      <h2 class="section__header">OUR PRICING PLAN</h2>
+      <p class="section__subheader">
+        Our pricing plan comes with various membership tiers, each tailored to
+        cater to different preferences and fitness aspirations.
+      </p>
+      <div class="price__grid">
+        <div class="price__card">
+          <div class="price__card__content">
+            <h4>Basic Plan</h4>
+            <h3>$10</h3>
+            <p>
+              <i class="ri-checkbox-circle-line"></i>
+              Smart workout plan
+            </p>
+            <p>
+              <i class="ri-checkbox-circle-line"></i>
+              At home workouts
+            </p>
+          </div>
+          <button class="btn price__btn">Join Now</button>
+        </div>
+        <div class="price__card">
+          <div class="price__card__content">
+            <h4>Monthly Plan</h4>
+            <h3>$80</h3>
+            <p>
+              <i class="ri-checkbox-circle-line"></i>
+              PRO Gyms
+            </p>
+            <p>
+              <i class="ri-checkbox-circle-line"></i>
+              Smart workout plan
+            </p>
+            <p>
+              <i class="ri-checkbox-circle-line"></i>
+              At home workouts
+            </p>
+          </div>
+          <button class="btn price__btn">Join Now</button>
+        </div>
+        <div class="price__card">
+          <div class="price__card__content">
+            <h4>Yearly Plan</h4>
+            <h3>$900</h3>
+            <p>
+              <i class="ri-checkbox-circle-line"></i>
+              ELITE Gyms & Classes
+            </p>
+            <p>
+              <i class="ri-checkbox-circle-line"></i>
+              PRO Gyms
+            </p>
+            <p>
+              <i class="ri-checkbox-circle-line"></i>
+              Smart workout plan
+            </p>
+            <p>
+              <i class="ri-checkbox-circle-line"></i>
+              At home workouts
+            </p>
+            <p>
+              <i class="ri-checkbox-circle-line"></i>
+              Personal Training
+            </p>
+          </div>
+          <button class="btn price__btn">Join Now</button>
+        </div>
+      </div>
+    </section>
+
+          
+        </body>
+        </html>

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
         <li class="link"><a href="#">Service</a></li>
         <li class="link"><a href="#diet-plan">Diet Plan</a></li>
         <li class="link"><a href="#">About</a></li>
+        <li class="link"><a href="Pricing Plan.html">Pricing Plan</a></li>
         <li class="link"><a href="contact.html">Contact Us</a></li>
       </ul>
       <button class="btn">Join Now</button>


### PR DESCRIPTION
This pull request implements the Pricing Plan page on the website, as proposed in the raised issue.
what's included:
1. Created a new Pricing Plan page 
2. linked the pricing plan page from the main(index) page.
3. Added navigation links to and from other website sections.
4. Ensured changes are committed in a separate feature branch for clean version control.
 this update improves the websites user experience by clearly presenting pricing options and enabling smooth navigation.
<img width="1920" height="1020" alt="Screenshot 2025-07-30 171144" src="https://github.com/user-attachments/assets/f76990d0-a738-43b7-80ba-8da556e6dc5b" />
